### PR TITLE
Fix bug in symbolic_execution.py 

### DIFF
--- a/arbiter/master_chief/symbolic_execution.py
+++ b/arbiter/master_chief/symbolic_execution.py
@@ -683,7 +683,7 @@ class SymExec(StaticAnalysis, DerefHook):
             return None
 
         output = {'function': first_target.addr, 'bbl': report.site.bbl,
-                  'bbl_history': list(sat_states[0].state.history.bbl_addrs),
+                  'bbl_history': list(sat_states[0].history.bbl_addrs),
                   'callstack': [x.current_function_address for x in sat_states[0].callstack]
                   }
         if report.site.callee == 'EOF':


### PR DESCRIPTION
I was getting an error when testing arbiter, because this line in `symbolic_execution.py` said that there was no attribute `state` on `SimState`.

`sat_states[0].state.history.bbl_addrs`

I think it should be 
`sat_states[0].history.bbl_addrs`, perhaps angr has changed and that's why this is necessary.