### PR TITLE
fix site bug

### DIFF
--- a/arbiter/master_chief/symbolic_execution.py
+++ b/arbiter/master_chief/symbolic_execution.py
@@ -169,7 +169,7 @@ class SymExec(StaticAnalysis, DerefHook):
 
         self._eliminate_false_positives(expr, init_val, state)
 
-        s = self.constrain(state, expr, init_val)
+        s = self.constrain(state, expr, init_val, site)
         if s is not None:
             state = s
 


### PR DESCRIPTION
when I ran CWE190_juliet_signed.py in your dataset like CWE190_s01, I found an error like this
```
Traceback (most recent call last):
  File "../../test_scripts/test_juliet_190_signed.py", line 78, in <module>
    do_stuff(sys.argv[1])
  File "../../test_scripts/test_juliet_190_signed.py", line 66, in do_stuff
    se.run_all()
  File "/usr/local/lib/python3.8/dist-packages/arbiter-0.0.1-py3.8.egg/arbiter/master_chief/symbolic_execution.py", line 456, in run_all
  File "/usr/local/lib/python3.8/dist-packages/arbiter-0.0.1-py3.8.egg/arbiter/master_chief/symbolic_execution.py", line 446, in run_one
  File "/usr/local/lib/python3.8/dist-packages/arbiter-0.0.1-py3.8.egg/arbiter/master_chief/symbolic_execution.py", line 429, in _execute_one
  File "/usr/local/lib/python3.8/dist-packages/arbiter-0.0.1-py3.8.egg/arbiter/master_chief/symbolic_execution.py", line 286, in _explore_one
  File "/usr/local/lib/python3.8/dist-packages/arbiter-0.0.1-py3.8.egg/arbiter/master_chief/symbolic_execution.py", line 251, in _check_state
  File "/usr/local/lib/python3.8/dist-packages/arbiter-0.0.1-py3.8.egg/arbiter/master_chief/symbolic_execution.py", line 172, in _apply_sz_constraints
TypeError: constrain() missing 1 required positional argument: 'site'
```
so I thougt constrain function may need site parameter